### PR TITLE
Restrict editing meeting to admin after votes.

### DIFF
--- a/DevCommunity/site/views/partials/home.jade
+++ b/DevCommunity/site/views/partials/home.jade
@@ -14,8 +14,8 @@
             h1 Meeting Idea
             .form-group
               label Title
-              input.form-control(type='text' ng-model='meeting.description')
-            .form-group
+              input.form-control(type='text' ng-model='meeting.description' ng-disabled="!canEdit")
+            .form-group(ng-show="canEdit")
               label Details
               textarea.form-control.ckeditor(id="newIdeaDetails" type='text' ng-model='meeting.details')
 

--- a/DevCommunity/source/Client/AddMeetingController.ts
+++ b/DevCommunity/source/Client/AddMeetingController.ts
@@ -27,12 +27,14 @@ class AddMeetingController {
             $scope.meeting = meeting;
             this.newIdeaRtb.setText(meeting.details);
             $('#AddTopicModal').modal('show');
-            $scope.errorMessage = "";
+            $scope.canEdit = userSvc.isAdmin() || meeting.vote_count == 0;
+            $scope.errorMessage = $scope.canEdit ? "" : "Only an admin can edit a meeting once it has received votes.";
         });
         $scope.$on('addMeeting', (event) => {
             $scope.meeting = meetingSvc.createMeeting();
             $('#AddTopicModal').modal('show');
             $scope.errorMessage = "";
+            $scope.canEdit = true;
         });
     }
 

--- a/DevCommunity/source/Client/IMeetingControllerScope.ts
+++ b/DevCommunity/source/Client/IMeetingControllerScope.ts
@@ -6,6 +6,7 @@ interface IMeetingControllerScope extends ng.IScope {
     errorMessage: string;
     sendEmail: boolean;
     schedMeetingMessage: string;
+    canEdit: boolean;
 }
 
 export = IMeetingControllerScope;


### PR DESCRIPTION
Once a meeting has votes only admins are allowed to edit meeting information. This will prevent a user from submitting an awesome meeting idea, getting a lot of votes, and then changing the meeting idea to be something terrible. (+1 squashed commits)